### PR TITLE
update files for release 4.2.0

### DIFF
--- a/adoc/attributes.adoc
+++ b/adoc/attributes.adoc
@@ -5,9 +5,9 @@
 // Product Versions
 
 //Counting upwards from 4, tied to SLE15 releases
-:productmajor: 5
+:productmajor: 4
 //Counting upwards from 0, tied to kubernetes releases
-:productminor: 0
+:productminor: 2
 //Counting upwards from 0, tied to maintenance release
 :productpatch: 0
 :prerelease:
@@ -21,19 +21,19 @@
 :kube_version: 1.17.4
 :kubedoc: https://v1-17.docs.kubernetes.io/docs/
 :cap_version: 1.5.2
-:cilium_release: 1.6
-:cilium_patch_version: 6
+:cilium_release: 1.5
+:cilium_patch_version: 3
 :cilium_version: {cilium_release}.{cilium_patch_version}
 :cilium_docs_version: v{cilium_release}
 :envoy_version: 1.12.2
 :etcd_version: 3.4.3
 :skuba_version: 1.3.3
 :dex_version: 2.16.0
-:gangway_version: 3.1.0-rev4
+:gangway_version: 3.1.0
 :metrics-server_version: 0.3.6
 :kured_version: 1.3.0
 :helm_tiller_version: 2.16.1
-:terraform_version: 0.12
+:terraform_version: 0.12.19
 :haproxy_version: 1.8.7
 
 // API versions

--- a/adoc/docinfo.xml
+++ b/adoc/docinfo.xml
@@ -8,4 +8,4 @@
 </dm:docmanager>
 
 <productname>SUSE CaaS Platform</productname>
-<productnumber>5.0.0</productnumber>
+<productnumber>4.2.0</productnumber>


### PR DESCRIPTION

Update files for 4.2.0

## release summary
Update to kubernetes 1.17, podman, cri-o and docs

## updated attributes

* productmajor
* productminor
* cilium_release
* cilium_patch_version
* gangway_version
* terraform_version
